### PR TITLE
Feature/updatenodejsboilerplate

### DIFF
--- a/templates/boilerplate/_dockerfiles/qxapp/python/Dockerfile
+++ b/templates/boilerplate/_dockerfiles/qxapp/python/Dockerfile
@@ -37,12 +37,12 @@ COPY services-rpc-api/*/gen-py ./
 
 COPY $serverdir/requirements.txt requirements.txt
 
-RUN pip3 install --no-cache-dir -r ./requirements.txt \
-    && python --version \
+RUN python --version \
+    && pip3 install --no-cache-dir -r ./requirements.txt \
     && pip list --format=columns
 
 COPY $serverdir/* ./
 
 EXPOSE 8080
 
-CMD ["python", "server.py"] 
+ENTRYPOINT ["python", "server.py"] 

--- a/templates/boilerplate/client-qx/source/class/qxapp/Application.js
+++ b/templates/boilerplate/client-qx/source/class/qxapp/Application.js
@@ -69,10 +69,12 @@ qx.Class.define("qxapp.Application",
       // Create operation buttons
       var button1 = new qx.ui.form.Button("WS: Do operation 1");
       var button2 = new qx.ui.form.Button("WS: Do operation 2");
+      
 
       // Add buttons and labels to document at fixed coordinates
       doc.add(button1, {left: 50, top: 100});
       doc.add(button2, {left: 250, top: 100});
+      
 
       // Add an event listeners
       button1.addListener("execute", function() {
@@ -97,7 +99,6 @@ qx.Class.define("qxapp.Application",
         this._socket.emit("operation2", input_number);
       }, this);
 
-
       var button3 = new qx.ui.form.Button("WS + S4L: Check App Version");
       doc.add(button3, {left: 50, top: 150});
       button3.addListener("execute", function() {
@@ -120,6 +121,18 @@ qx.Class.define("qxapp.Application",
           });
         }
         this._socket.emit("checkS4LModVersion");
+      }, this);
+
+      var button5 = new qx.ui.form.Button('WS + S4L: Create Cylinder');
+      doc.add(button5, {left: 450, top: 150});
+      button5.addListener("execute", function() {
+        if (!this._socket.slotExists("createS4LSolidCylinder")) {
+          this._socket.on("createS4LSolidCylinder", function(val) {
+            console.log(val);
+            alert("Result of creating solid cylinder: " + val);
+          });
+        }
+        this._socket.emit("createS4LSolidCylinder");
       }, this);
     },
   }

--- a/templates/boilerplate/client-qx/source/class/qxapp/Application.js
+++ b/templates/boilerplate/client-qx/source/class/qxapp/Application.js
@@ -123,17 +123,17 @@ qx.Class.define("qxapp.Application",
         this._socket.emit("checkS4LModVersion");
       }, this);
 
-      var button5 = new qx.ui.form.Button('WS + S4L: Create Cylinder');
+      let button5 = new qx.ui.form.Button('WS + S4L: Create Cylinder');
       doc.add(button5, {left: 450, top: 150});
-      button5.addListener("execute", function() {
-        if (!this._socket.slotExists("createS4LSolidCylinder")) {
-          this._socket.on("createS4LSolidCylinder", function(val) {
+      button5.addListener('execute', function() {
+        if (!scope._socket.slotExists('createS4LSolidCylinder')) {
+          scope._socket.on('createS4LSolidCylinder', function(val) {
             console.log(val);
-            alert("Result of creating solid cylinder: " + val);
+            alert('Result of creating solid cylinder: ' + val);
           });
         }
-        this._socket.emit("createS4LSolidCylinder");
-      }, this);
+        scope._socket.emit('createS4LSolidCylinder');
+      }, scope);
     },
   }
 });

--- a/templates/boilerplate/server-py-aiohttp/async_sio.py
+++ b/templates/boilerplate/server-py-aiohttp/async_sio.py
@@ -37,17 +37,35 @@ async def op2_handler(sid, data):
 
 @sio.on('checkS4LAppVersion')
 async def s4l_check_app_version(sid, data):
-    version = services.APP.GetApiVersion()
-    logging.debug("S4L App version %s", version)
-    await sio.emit('checkS4LAppVersion',
-                   data=dict(major=version.major, minor=version.minor), room=sid)
+    try:
+        version = services.APP('GetApiVersion')
+        logging.debug("S4L App version %s", version)
+        await sio.emit('checkS4LAppVersion',
+                    data=dict(major=version.major, minor=version.minor), room=sid)
+    except Exception:
+        pass
+    
 
 
 @sio.on('checkS4LModVersion')
-async def s4l_check_app_version(sid, data):
-    version = services.MODEL.GetApiVersion()
-    logging.debug("S4L Mode version %s", version)
-    await sio.emit('checkS4LModVersion', data=dict(major=version.major, minor=version.minor), room=sid)
+async def s4l_check_modeler_version(sid, data):
+    try:
+        version = services.MODEL('GetApiVersion')
+        logging.debug("S4L Mode version %s", version)
+        await sio.emit('checkS4LModVersion', data=dict(major=version.major, minor=version.minor), room=sid)
+    except Exception:
+        pass
+
+@sio.on('createS4LSolidCylinder')
+async def create_S4L_solid_cylinder(sid, data):
+    from services import modeler
+    try:
+        services.APP('NewDocument')
+        uuid = services.MODEL('CreateSolidCylinder', modeler.Modeler.Vertex(0,0,0), modeler.Modeler.Vertex(25,35,34), 25.5, u'')
+        logging.debug('S4L created cylinder with uuid %s', uuid)
+        await sio.emit('createS4LSolidCylinder', data=uuid, room=sid)
+    except Exception:
+        pass
 
 
 @sio.on('disconnect')

--- a/templates/boilerplate/server-py-aiohttp/config.py
+++ b/templates/boilerplate/server-py-aiohttp/config.py
@@ -38,6 +38,7 @@ class CommonConfig:
     CS_S4L_PORT_MOD = os.environ.get('CS_S4L_PORT_MOD', 9096)
 
     THRIFT_GEN_OUTDIR = THRIFT_GEN_OUTDIR
+    THRIFT_USE_MULTIPLEXED_SERVER = os.environ.get('THRIFT_USE_MULTIPLEXED_SERVER', True)
 
     @staticmethod
     def init_app(app):

--- a/templates/boilerplate/server-py-aiohttp/services.py
+++ b/templates/boilerplate/server-py-aiohttp/services.py
@@ -152,7 +152,9 @@ class XRpcConnectionManager:
     xRpcClient = None
     
     @staticmethod
-    def connect():        
+    def connect(): 
+    """tries to connect to the Thrift RPC interface of the XRpcWorker
+    """               
         _CONFIG = CONFIG[os.environ.get('SIMCORE_WEB_CONFIG', 'default')]
         try:
             XRpcConnectionManager.xRpcClient = xRpcModelerInterface(_CONFIG)
@@ -162,7 +164,14 @@ class XRpcConnectionManager:
             raise
 
     @staticmethod
-    def callRPCFunction(rpcService, fctName, *args):
+    def call_rpc_function(rpcService, fctName, *args):
+        """wraps the call to an RPC method such that disconnection can be detected
+        
+        Arguments:
+            rpcService {string} -- name of the service
+            fctName {string} -- name of the function
+            *args -- any number of arguments as defined in the Thrift interface
+        """
         if XRpcConnectionManager.xRpcClient is None:
             # try to connect
             XRpcConnectionManager.connect()
@@ -177,7 +186,7 @@ class XRpcConnectionManager:
             raise
 
 def MODEL(fctName, *args):
-    return XRpcConnectionManager.callRPCFunction('modelerClient', fctName, *args)
+    return XRpcConnectionManager.call_rpc_function('modelerClient', fctName, *args)
 
 def APP(fctName, *args):
-    return XRpcConnectionManager.callRPCFunction('applicationClient', fctName, *args)
+    return XRpcConnectionManager.call_rpc_function('applicationClient', fctName, *args)

--- a/templates/boilerplate/server-py-aiohttp/services.py
+++ b/templates/boilerplate/server-py-aiohttp/services.py
@@ -26,8 +26,8 @@ import modeler.Modeler
 
 xRpcClient = None
 class xRpcModelerInterface:
-    applicationClient = 0
-    modelerClient = 0
+    applicationClient = None
+    modelerClient = None
 
     def create_transport(self, ip, port):
         """creates a Thrift transport

--- a/templates/boilerplate/server-py-aiohttp/services.py
+++ b/templates/boilerplate/server-py-aiohttp/services.py
@@ -3,6 +3,7 @@
 """
 import os
 import sys
+import logging
 
 import thrift
 import thrift.protocol
@@ -152,7 +153,7 @@ def connect():
     try:
         xRpcClient = xRpcModelerInterface(_CONFIG)
     except Thrift.TException as e:
-        print('Thrift exception: ', e)
+        logging.exception('Thrift exception: %s', e)
         xRpcClient = None
         raise
 
@@ -167,7 +168,7 @@ def callRPCFunction(rpcService, fctName, *args):
         results = method_to_call(*args)
         return results
     except Exception as e:
-        print('Thrift exception: ', e)
+        logging.exception('Thrift exception: %s', e)
         xRpcClient = None
         raise
 

--- a/templates/boilerplate/server-py-aiohttp/services.py
+++ b/templates/boilerplate/server-py-aiohttp/services.py
@@ -42,26 +42,26 @@ class xRpcModelerInterface:
         protocol = TBinaryProtocol.TBinaryProtocol(transport)
         return protocol
 
-    def create_client_and_open_connection(self, transport, protocol, client_service):
+    def create_client_open_connection(self, transport, protocol, service):
         # Create the client
-        client = client_service.Client(protocol)
+        client = service.Client(protocol)
         # Connect
         transport.open()
         return client
 
-    def connect_to_std_buffer_interface(self, ip, port, client_service):
+    def connect_std_buffer_interface(self, ip, port, service):
         transport = self.create_transport(ip, port)
         protocol = self.create_protocol(transport)
-        return self.create_client_and_open_connection(transport, protocol, client_service)
+        return self.create_client_open_connection(transport, protocol, service)
 
-    def connect_to_multiplexed_interface(self, ip, port, service_name, client_service):
+    def connect_multiplexed_interface(self, ip, port, service_name, service):
         from thrift.protocol import TMultiplexedProtocol    
         
         transport = self.create_transport(ip, port)
         protocol = self.create_protocol(transport)
         # update the protocol to a multiplexed protocol (several services are agregated on the same port)
         multiplexedProtocol = TMultiplexedProtocol.TMultiplexedProtocol(protocol, service_name)
-        return self.create_client_and_open_connection(transport, multiplexedProtocol, client_service)
+        return self.create_client_open_connection(transport, multiplexedProtocol, service)
 
     def create_clients_std(self, ip, *ports):
         """
@@ -69,17 +69,17 @@ class xRpcModelerInterface:
         """
         port0, port1 = ports if len(ports) == 2 else (ports[0], ports[0]+1)
 
-        self.applicationClient = self.connect_to_std_buffer_interface(
+        self.applicationClient = self.connect_std_buffer_interface(
             ip, port0, application.Application)
 
-        self.modelerClient = self.connect_to_std_buffer_interface(
+        self.modelerClient = self.connect_std_buffer_interface(
             ip, port1, modeler.Modeler)
 
 
     def create_clients_multiplexed(self, ip, port):
-        self.applicationClient = self.connect_to_multiplexed_interface(
+        self.applicationClient = self.connect_multiplexed_interface(
             ip, port, 'Application', application.Application)
-        self.modelerClient = self.connect_to_multiplexed_interface(
+        self.modelerClient = self.connect_multiplexed_interface(
             ip, port, 'Modeler', modeler.Modeler)
 
     def create_clients(self, config):


### PR DESCRIPTION
- Python server using aiohttp now connects at runtime to modeler service and handles disconnections and reconnections instead of connecting at start time and crashing if no connection possible.
- to this end wrapped calls to RPC services to detect disconnection (could be useful for other RPC services later on)
- refactored services.py file